### PR TITLE
test: add tests to ReactFiberLane

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ aliases:
     restore_cache:
       name: Restore node_modules cache
       keys:
-        - v2-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}-node-modules
+        - v2-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}-node-modules
 
   - &TEST_PARALLELISM 20
 
@@ -29,6 +29,7 @@ aliases:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: node ./scripts/rollup/consolidateBundleSizes.js
       - run: ./scripts/circleci/pack_and_store_artifact.sh
@@ -51,7 +52,6 @@ jobs:
   setup:
     docker: *docker
     environment: *environment
-
     steps:
       - checkout
       - run:
@@ -61,6 +61,7 @@ jobs:
       - run:
           name: Install Packages
           command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - save_cache:
           # Store the yarn cache globally for all lock files with this same
           # checksum. This will speed up the setup job for all PRs where the
@@ -75,7 +76,7 @@ jobs:
           # all jobs run on this branch with the same lockfile.
           name: Save node_modules cache
           # This cache key is per branch, a yarn install in setup is required.
-          key: v2-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}-node-modules
+          key: v2-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}-node-modules
           paths:
             - node_modules
 
@@ -85,6 +86,7 @@ jobs:
 
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: node ./scripts/prettier/index
       - run: node ./scripts/tasks/eslint
@@ -98,6 +100,7 @@ jobs:
 
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: node ./scripts/tasks/flow-ci
 
@@ -108,6 +111,7 @@ jobs:
 
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-stable --ci
 
@@ -117,6 +121,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test --ci
 
@@ -126,6 +131,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-classic --ci
 
@@ -135,6 +141,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-classic --variant --ci
 
@@ -144,6 +151,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-classic --prod --ci
 
@@ -153,6 +161,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-classic --prod --variant --ci
 
@@ -162,6 +171,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-www --ci
 
@@ -171,6 +181,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-www --variant --ci
 
@@ -180,6 +191,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-www --prod --ci
 
@@ -189,6 +201,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-www --prod --variant --ci
 
@@ -199,6 +212,7 @@ jobs:
 
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-stable --persistent --ci
 
@@ -209,6 +223,7 @@ jobs:
 
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-stable --prod --ci
 
@@ -218,6 +233,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test --prod --ci
 
@@ -227,6 +243,7 @@ jobs:
     parallelism: *TEST_PARALLELISM
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run:
           environment:
@@ -254,6 +271,7 @@ jobs:
     parallelism: 20
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run:
           environment:
@@ -281,6 +299,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_yarn_cache
       - *restore_node_modules
       - run:
@@ -299,6 +318,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_yarn_cache
       - *restore_node_modules
       - run:
@@ -326,6 +346,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: packages/react-devtools-scheduling-profiler
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run:
           name: Deploy
@@ -344,6 +365,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       # This runs in the process_artifacts job, too, but it's faster to run
       # this step in both jobs instead of running the jobs sequentially
@@ -359,6 +381,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       # This runs in the process_artifacts job, too, but it's faster to run
       # this step in both jobs instead of running the jobs sequentially
@@ -374,6 +397,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn lint-build
       - run: scripts/circleci/check_minified_errors.sh
@@ -384,6 +408,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run:
           environment:
@@ -398,6 +423,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-stable --build --ci
 
@@ -408,6 +434,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test --build --ci
 
@@ -417,6 +444,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test --project=devtools --build --ci
 
@@ -426,6 +454,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run:
           name: Run DOM fixture tests
@@ -442,6 +471,7 @@ jobs:
     environment: *environment
     steps:
       - checkout
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run:
           name: Run fuzz tests
@@ -456,6 +486,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test-stable --build --prod --ci
 
@@ -466,6 +497,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
+      - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run: yarn test --build --prod --ci
 

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -629,7 +629,11 @@ export function laneToLanes(lane: Lane): Lanes {
 
 export function higherPriorityLane(a: Lane, b: Lane) {
   // This works because the bit ranges decrease in priority as you go left.
-  return a !== NoLane && a < b ? a : b;
+  if (a !== NoLane && b !== NoLane) {
+    return a < b ? a : b;
+  } else {
+    return a !== NoLane ? a : b;
+  }
 }
 
 export function higherLanePriority(

--- a/packages/react-reconciler/src/__tests__/ReactFiberLane-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberLane-test.internal.js
@@ -14,7 +14,7 @@ const {
   NormalPriority,
   NoPriority,
   UserBlockingPriority,
-} = require('react-reconciler/src/SchedulerWithReactIntegration.new');
+} = require('../SchedulerWithReactIntegration.new');
 
 let ReactFiberLane;
 

--- a/packages/react-reconciler/src/__tests__/ReactFiberLane-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberLane-test.js
@@ -9,12 +9,12 @@
  */
 'use strict';
 
-import {
+const {
   ImmediatePriority,
   NormalPriority,
   NoPriority,
   UserBlockingPriority,
-} from 'react-reconciler/src/SchedulerWithReactIntegration.new';
+} = require('react-reconciler/src/SchedulerWithReactIntegration.new');
 
 let ReactFiberLane;
 
@@ -22,7 +22,7 @@ describe('ReactFiberLane', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    ReactFiberLane = require('react-reconciler/src/ReactFiberLane');
+    ReactFiberLane = require('../ReactFiberLane');
   });
 
   describe('lanePriorityToSchedulerPriority', () => {

--- a/packages/react-reconciler/src/__tests__/ReactFiberLane-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberLane-test.js
@@ -1,0 +1,295 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+'use strict';
+
+import {
+  ImmediatePriority,
+  NormalPriority,
+  NoPriority,
+  UserBlockingPriority,
+} from 'react-reconciler/src/SchedulerWithReactIntegration.new';
+
+let ReactFiberLane;
+
+describe('ReactFiberLane', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    ReactFiberLane = require('react-reconciler/src/ReactFiberLane');
+  });
+
+  describe('lanePriorityToSchedulerPriority', () => {
+    const INVALID_PRIORITY_LANE = 999;
+
+    const expectedPriorities = {
+      SyncLanePriority: ImmediatePriority,
+      SyncBatchedLanePriority: ImmediatePriority,
+      InputDiscreteLanePriority: UserBlockingPriority,
+      InputContinuousLanePriority: UserBlockingPriority,
+      DefaultLanePriority: NormalPriority,
+      TransitionPriority: NormalPriority,
+      NoLanePriority: NoPriority,
+    };
+
+    Object.keys(expectedPriorities).forEach(priorityName => {
+      const priority = expectedPriorities[priorityName];
+      it(`returns the expected priority (${priority}) for lane ${priorityName}`, () => {
+        const lane = ReactFiberLane[priorityName];
+        expect(lane).toBeDefined();
+        expect(ReactFiberLane.lanePriorityToSchedulerPriority(lane)).toEqual(
+          priority,
+        );
+      });
+    });
+
+    it('throws when giving an invalid lane priority', () => {
+      expect(() => {
+        ReactFiberLane.lanePriorityToSchedulerPriority(INVALID_PRIORITY_LANE);
+      }).toThrow(
+        `Invalid update priority: ${INVALID_PRIORITY_LANE}. This is a bug in React`,
+      );
+    });
+  });
+
+  describe('getHighestPriorityPendingLanes', () => {
+    it('returns the Sync lane and sets the sync lane priority', () => {
+      const root = {pendingLanes: ReactFiberLane.SyncLane};
+      const lane = ReactFiberLane.getHighestPriorityPendingLanes(root);
+
+      expect(lane).toEqual(ReactFiberLane.SyncLane);
+      const nextLanesPriority = ReactFiberLane.returnNextLanesPriority();
+      expect(nextLanesPriority).toEqual(ReactFiberLane.SyncLanePriority);
+    });
+  });
+
+  describe('getNextLanes', () => {
+    describe('given no pending lanes', () => {
+      let root;
+
+      beforeEach(() => {
+        root = {pendingLanes: ReactFiberLane.NoLanes};
+      });
+
+      it('returns no lanes', () => {
+        expect(
+          ReactFiberLane.getNextLanes(root, ReactFiberLane.NoLanes),
+        ).toEqual(ReactFiberLane.NoLanes);
+      });
+
+      it('sets the highest lane priority to no lane', () => {
+        ReactFiberLane.getNextLanes(root, ReactFiberLane.NoLanes);
+
+        expect(ReactFiberLane.returnNextLanesPriority()).toEqual(
+          ReactFiberLane.NoLanePriority,
+        );
+      });
+    });
+  });
+
+  describe('includesNonIdleWork', () => {
+    const nonIdleLaneNames = [
+      'SyncLane',
+      'SyncBatchedLane',
+      'InputDiscreteHydrationLane',
+      'DefaultHydrationLane',
+      'SomeRetryLane',
+      'SelectiveHydrationLane',
+    ];
+
+    nonIdleLaneNames.forEach(laneName => {
+      it(`is true for ${laneName}`, () => {
+        const lane = ReactFiberLane[laneName];
+        expect(lane).toBeDefined();
+        expect(ReactFiberLane.includesNonIdleWork(lane)).toEqual(true);
+      });
+    });
+
+    const idleLaneNames = ['NoLane', 'OffscreenLane', 'IdleHydrationLane'];
+
+    idleLaneNames.forEach(laneName => {
+      it(`is false for ${laneName}`, () => {
+        const lane = ReactFiberLane[laneName];
+        expect(lane).toBeDefined();
+        expect(ReactFiberLane.includesNonIdleWork(lane)).toEqual(false);
+      });
+    });
+  });
+
+  describe('includesOnlyRetries', () => {
+    it('is true for a retry lane', () => {
+      expect(
+        ReactFiberLane.includesOnlyRetries(ReactFiberLane.SomeRetryLane),
+      ).toEqual(true);
+    });
+
+    it('is false for the sync lane', () => {
+      expect(
+        ReactFiberLane.includesOnlyRetries(ReactFiberLane.SyncLane),
+      ).toEqual(false);
+    });
+
+    it('is false for a retry lane merged with another lane', () => {
+      const mergedLanes = ReactFiberLane.mergeLanes(
+        ReactFiberLane.SyncLane,
+        ReactFiberLane.SomeRetryLane,
+      );
+      expect(ReactFiberLane.includesOnlyRetries(mergedLanes)).toEqual(false);
+    });
+  });
+
+  describe('includesSomeLane', () => {
+    it('is true given the same lane', () => {
+      const lane = ReactFiberLane.SyncLane;
+      expect(ReactFiberLane.includesSomeLane(lane, lane)).toEqual(true);
+    });
+
+    it('is true given lanes that includes the other', () => {
+      const lane = ReactFiberLane.SyncLane;
+      const mergedLanes = ReactFiberLane.mergeLanes(
+        lane,
+        ReactFiberLane.DefaultHydrationLane,
+      );
+
+      expect(ReactFiberLane.includesSomeLane(mergedLanes, lane)).toEqual(true);
+    });
+
+    it('is false for two seperate lanes', () => {
+      expect(
+        ReactFiberLane.includesSomeLane(
+          ReactFiberLane.SyncLane,
+          ReactFiberLane.DefaultHydrationLane,
+        ),
+      ).toEqual(false);
+    });
+  });
+
+  describe('isSubsetOfLanes', () => {
+    it('is true given the same lane', () => {
+      const lane = ReactFiberLane.SyncLane;
+      expect(ReactFiberLane.isSubsetOfLanes(lane, lane)).toEqual(true);
+    });
+
+    it('is true given lanes that includes the other', () => {
+      const subset = ReactFiberLane.mergeLanes(
+        ReactFiberLane.SyncLane,
+        ReactFiberLane.DefaultHydrationLane,
+      );
+      const mergedLanes = ReactFiberLane.mergeLanes(
+        subset,
+        ReactFiberLane.SyncBatchedLane,
+      );
+
+      expect(ReactFiberLane.includesSomeLane(mergedLanes, subset)).toEqual(
+        true,
+      );
+    });
+
+    it('is false for two seperate lanes', () => {
+      expect(
+        ReactFiberLane.includesSomeLane(
+          ReactFiberLane.SyncLane,
+          ReactFiberLane.DefaultHydrationLane,
+        ),
+      ).toEqual(false);
+    });
+  });
+
+  describe('mergeLanes', () => {
+    it('returns a lane that includes both inputs', () => {
+      const laneA = ReactFiberLane.SyncLane;
+      const laneB = ReactFiberLane.DefaultHydrationLane;
+
+      const mergedLanes = ReactFiberLane.mergeLanes(laneA, laneB);
+
+      expect(ReactFiberLane.includesSomeLane(mergedLanes, laneA)).toEqual(true);
+      expect(ReactFiberLane.includesSomeLane(mergedLanes, laneB)).toEqual(true);
+    });
+
+    it('returns the same lane given two identical lanes', () => {
+      const lane = ReactFiberLane.SyncLane;
+      expect(ReactFiberLane.mergeLanes(lane, lane)).toEqual(lane);
+    });
+  });
+
+  describe('removeLanes', () => {
+    it('returns the lanes without the given lane', () => {
+      const laneA = ReactFiberLane.SyncLane;
+      const laneB = ReactFiberLane.DefaultHydrationLane;
+      const mergedLanes = ReactFiberLane.mergeLanes(laneA, laneB);
+
+      expect(ReactFiberLane.removeLanes(mergedLanes, laneA)).toEqual(laneB);
+      expect(ReactFiberLane.removeLanes(mergedLanes, laneB)).toEqual(laneA);
+    });
+
+    it('returns the same lane when removing a lane not included', () => {
+      const lanes = ReactFiberLane.mergeLanes(
+        ReactFiberLane.SyncLane,
+        ReactFiberLane.DefaultHydrationLane,
+      );
+
+      expect(
+        ReactFiberLane.removeLanes(lanes, ReactFiberLane.SyncBatchedLane),
+      ).toEqual(lanes);
+    });
+  });
+
+  describe('higherPriorityLane', () => {
+    it('returns the other lane if one is NoLane', () => {
+      const lane = ReactFiberLane.SyncLane;
+
+      expect(
+        ReactFiberLane.higherPriorityLane(ReactFiberLane.NoLane, lane),
+      ).toEqual(lane);
+      expect(
+        ReactFiberLane.higherPriorityLane(lane, ReactFiberLane.NoLane),
+      ).toEqual(lane);
+    });
+
+    it('returns the higher priority lane', () => {
+      const higherLane = ReactFiberLane.SyncLane;
+      const otherLane = ReactFiberLane.OffscreenLane;
+      expect(ReactFiberLane.higherPriorityLane(higherLane, otherLane)).toEqual(
+        higherLane,
+      );
+      expect(ReactFiberLane.higherPriorityLane(otherLane, higherLane)).toEqual(
+        higherLane,
+      );
+    });
+  });
+
+  describe('higherLanePriority', () => {
+    it('returns the other priority if one is NoLanePriority', () => {
+      const priority = ReactFiberLane.DefaultLanePriority;
+      expect(
+        ReactFiberLane.higherLanePriority(
+          ReactFiberLane.NoLanePriority,
+          priority,
+        ),
+      ).toEqual(priority);
+      expect(
+        ReactFiberLane.higherLanePriority(
+          priority,
+          ReactFiberLane.NoLanePriority,
+        ),
+      ).toEqual(priority);
+    });
+
+    it('returns the higher lane priority', () => {
+      const higherPriority = ReactFiberLane.SyncLanePriority;
+      const otherPriority = ReactFiberLane.TransitionPriority;
+      expect(
+        ReactFiberLane.higherLanePriority(higherPriority, otherPriority),
+      ).toEqual(higherPriority);
+      expect(
+        ReactFiberLane.higherLanePriority(otherPriority, higherPriority),
+      ).toEqual(higherPriority);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

These changes add unit tests to ReactFiberLane. A test case discovered a potential issue with the function `higherPriorityLane`. If
the second argument is `NoLane`, it returns `NoLane` instead of returning the first given lane. 

In summary, this expectation fail:

```js
expect(higherPriorityLane(SyncLane, NoLane)).toEqual(SyncLane)
```

I made the changes to make that test pass.

## Test Plan

All tests should pass.

---

I started with some of the smaller functions to get coverage on the building blocks, then I'll move to those with more behavior.